### PR TITLE
Update golang package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,7 @@
----
 cf-rabbitmq-multitenant-broker-golang/go1.12.7.linux-amd64.tar.gz:
   size: 127959471
   object_id: d4f2bbd2-f523-455c-6a42-f64d6fa6001c
   sha: sha256:66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9
+cf-rabbitmq-multitenant-broker-golang/go1.12.8.linux-amd64.tar.gz:
+  size: 127961104
+  sha: sha256:bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2


### PR DESCRIPTION
This PR updates the version of golang to 1.12.8