### PR TITLE
Support TLS for connection to RMQ management API

### DIFF
--- a/jobs/rabbitmq-service-broker/spec
+++ b/jobs/rabbitmq-service-broker/spec
@@ -29,6 +29,14 @@ properties:
     description: "Set to true if RabbitMQ cluster is configured to use TLS/SSL"
   rabbitmq-service-broker.rabbitmq.management_domain:
     description: "Domain that will be used to access RabbitMQ management UI, typically the system CF/CC domain."
+  rabbitmq-service-broker.rabbitmq.management_tls.enabled:
+    default: false
+    description: "Set to true if the RabbitMQ management plugin is configured to use TLS/SSL"
+  rabbitmq-service-broker.rabbitmq.management_tls.cacert:
+    description: "PEM-encoded CA/intermediate certificate chain to trust when connecting to the management plugin over TLS. Uses system cert pool if not provided."
+  rabbitmq-service-broker.rabbitmq.management_tls.skip_verify:
+    default: false
+    description: "Set to true to skip verifying the certificate served by the management plugin. Not recommended for production."
   rabbitmq-service-broker.logging.level:
     default: "info"
     description: "Logging level"

--- a/src/rabbitmq-service-broker/config/config.go
+++ b/src/rabbitmq-service-broker/config/config.go
@@ -46,6 +46,7 @@ type RabbitMQ struct {
 	DNSHost           string                `yaml:"dns_host"`
 	Administrator     AdminCredentials      `yaml:"administrator" validate:"required"`
 	Management        ManagementCredentials `yaml:"management"`
+	ManagementTLS     ManagementTLS         `yaml:"management_tls"`
 	ManagementDomain  string                `yaml:"management_domain" validate:"required"`
 	OperatorSetPolicy RabbitMQPolicy        `yaml:"operator_set_policy"`
 	RegularUserTags   string                `yaml:"regular_user_tags"`
@@ -54,6 +55,12 @@ type RabbitMQ struct {
 
 type ManagementCredentials struct {
 	Username string `yaml:"username"`
+}
+
+type ManagementTLS struct {
+	Enabled    bool   `yaml:"enabled"`
+	CACert     string `yaml:"cacert"`
+	SkipVerify bool   `yaml:"skip_verify"`
 }
 
 type AdminCredentials struct {


### PR DESCRIPTION
Previously, it was hardcoded to use http only. Now, it can take arguments to use https, as well as a certificate chain to trust as the CA pool when connecting, or to skip certificate validation entirely.

This likely closes #39, or at least addresses the concerns in the comments under it.