### PR TITLE
Fix non-TLS AMQP scheme when TLS enabled

### DIFF
--- a/src/rabbitmq-service-broker/binding/binding.go
+++ b/src/rabbitmq-service-broker/binding/binding.go
@@ -60,7 +60,7 @@ func (b Builder) dashboardURL() string {
 }
 
 func (b Builder) uriForBinding(hostname string) string {
-	return fmt.Sprintf("%s://%s:%s@%s/%s", b.amqpScheme(), b.Username, b.Password, hostname, b.VHost)
+	return fmt.Sprintf("%s://%s:%s@%s/%s", b.amqpScheme(b.TLS), b.Username, b.Password, hostname, b.VHost)
 }
 
 func (b Builder) urisForBinding() []string {

--- a/src/rabbitmq-service-broker/binding/binding_test.go
+++ b/src/rabbitmq-service-broker/binding/binding_test.go
@@ -72,6 +72,7 @@ func fakeNonTLSProtocolPorts() map[string]int {
 
 func fakeTLSProtocolPorts() map[string]int {
 	return map[string]int{
+		"amqp":           5672,
 		"amqp/ssl":       5671,
 		"clustering":     25672,
 		"http":           15672,

--- a/src/rabbitmq-service-broker/binding/common.go
+++ b/src/rabbitmq-service-broker/binding/common.go
@@ -4,8 +4,8 @@ func (b Builder) firstHostname() string {
 	return b.Hostnames[0]
 }
 
-func (b Builder) amqpScheme() string {
-	if b.TLS {
+func (b Builder) amqpScheme(tls bool) string {
+	if tls {
 		return "amqps"
 	}
 	return "amqp"

--- a/src/rabbitmq-service-broker/binding/fixtures/binding_tls.json
+++ b/src/rabbitmq-service-broker/binding/fixtures/binding_tls.json
@@ -11,6 +11,23 @@
  ],
  "password": "cfrnvvjtr6t803ilrdhgbe8mn7",
  "protocols": {
+  "amqp": {
+   "host": "10.0.4.100",
+   "hosts": [
+    "10.0.4.100",
+    "10.0.4.101"
+   ],
+   "password": "cfrnvvjtr6t803ilrdhgbe8mn7",
+   "port": 5672,
+   "ssl": false,
+   "uri": "amqp://b2a5de47-796b-414d-bab4-eb299c268653:cfrnvvjtr6t803ilrdhgbe8mn7@10.0.4.100:5672/6418d19f-e9e8-4c8b-9c92-5087c89cbc46",
+   "uris": [
+    "amqp://b2a5de47-796b-414d-bab4-eb299c268653:cfrnvvjtr6t803ilrdhgbe8mn7@10.0.4.100:5672/6418d19f-e9e8-4c8b-9c92-5087c89cbc46",
+    "amqp://b2a5de47-796b-414d-bab4-eb299c268653:cfrnvvjtr6t803ilrdhgbe8mn7@10.0.4.101:5672/6418d19f-e9e8-4c8b-9c92-5087c89cbc46"
+   ],
+   "username": "b2a5de47-796b-414d-bab4-eb299c268653",
+   "vhost": "6418d19f-e9e8-4c8b-9c92-5087c89cbc46"
+  },
   "amqp+ssl": {
    "host": "10.0.4.100",
    "hosts": [

--- a/src/rabbitmq-service-broker/binding/protocol_amqp.go
+++ b/src/rabbitmq-service-broker/binding/protocol_amqp.go
@@ -9,21 +9,21 @@ func (b Builder) addAMQPProtocol(port int, tls bool) protocol {
 		VHost:     b.VHost,
 		Hostname:  b.firstHostname(),
 		Hostnames: b.Hostnames,
-		URI:       b.uriForAMQP(b.firstHostname(), port),
-		URIs:      b.urisForAMQP(port),
+		URI:       b.uriForAMQP(b.firstHostname(), port, tls),
+		URIs:      b.urisForAMQP(port, tls),
 		Port:      port,
 		TLS:       tls,
 	}
 }
 
-func (b Builder) uriForAMQP(hostname string, port int) string {
-	return fmt.Sprintf("%s://%s:%s@%s:%d/%s", b.amqpScheme(), b.Username, b.Password, hostname, port, b.VHost)
+func (b Builder) uriForAMQP(hostname string, port int, tls bool) string {
+	return fmt.Sprintf("%s://%s:%s@%s:%d/%s", b.amqpScheme(tls), b.Username, b.Password, hostname, port, b.VHost)
 }
 
-func (b Builder) urisForAMQP(port int) []string {
+func (b Builder) urisForAMQP(port int, tls bool) []string {
 	var uris []string
 	for _, hostname := range b.Hostnames {
-		uris = append(uris, b.uriForAMQP(hostname, port))
+		uris = append(uris, b.uriForAMQP(hostname, port, tls))
 	}
 	return uris
 }


### PR DESCRIPTION
As of https://github.com/pivotal-cf/cf-rabbitmq-release/pull/394, a bug
was fixed which disabled the non-TLS AMQP listener when TLS was enabled
& disable_non_ssl_listeners was disabled.

This revealed a bug in the multitenant broker which assumed that only
one of AMQP or AMQPS can be enabled at a time, resulting in the
incorrect scheme for non-TLS AMQP bindings. This PR fixes that second
bug.