### PR TITLE
Revert "Bump bosh-template from 2.1.0 to 2.3.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     amq-protocol (2.3.2)
     ansi (1.5.0)
-    bosh-template (2.3.0)
+    bosh-template (2.1.0)
       semi_semantic (~> 1.2.0)
     bunny (2.22.0)
       amq-protocol (~> 2.3, >= 2.3.1)


### PR DESCRIPTION
Reverts pivotal-cf/cf-rabbitmq-multitenant-broker-release#186