### PR TITLE
[TNZ-100079] Add admin_client and secret for smoke tests

### DIFF
--- a/manifests/cf-rabbitmq-broker-template.yml
+++ b/manifests/cf-rabbitmq-broker-template.yml
@@ -108,6 +108,8 @@ instance_groups:
         domain: ((system-domain))
         admin_username: ((cf-admin-username))
         admin_password: ((cf-admin-password))
+        admin_client: ((cf-admin-client))
+        admin_client_secret: ((cf-admin-client-secret))
       broker:
         name: ((product-name))
       smoke_tests:

--- a/manifests/ci/create-manifest.sh
+++ b/manifests/ci/create-manifest.sh
@@ -26,6 +26,8 @@ bosh interpolate \
 	--vars-file=cf-rabbitmq-pipelines/manifests/vars-files/cf-rabbitmq-multitenant-broker-vars.yml \
 	--vars-file=cf-rabbitmq-pipelines/manifests/vars-files/smith-cf-deployment-vars.yml \
 	--var cf-admin-password="$(om -k curl -s -p "/api/v0/deployed/products/$cf_guid/credentials/.uaa.admin_credentials" | jq -r .credential.value.password)" \
+	--var cf-admin-client="((/opsmgr/${BOSH_DEPLOYMENT}/uaa/tile_installer_client_credentials.identity))" \
+	--var cf-admin-client-secret="((/opsmgr/${BOSH_DEPLOYMENT}/uaa/tile_installer_client_credentials.password))" \
 	--var nats-client-cert="((/opsmgr/${BOSH_DEPLOYMENT}/nats_client_cert.cert_pem))" \
 	--var nats-client-key="((/opsmgr/${BOSH_DEPLOYMENT}/nats_client_cert.private_key_pem))" \
 	--var system-domain="$DOMAIN" \


### PR DESCRIPTION
## Changes

1. **`manifests/cf-rabbitmq-broker-template.yml`**: Added `admin_client` and `admin_client_secret` fields under the CF UAA configuration block, sourced from the `((cf-admin-client))` and `((cf-admin-client-secret))` BOSH variables.

2. **`manifests/ci/create-manifest.sh`**: Added `--var` flags to interpolate `cf-admin-client` and `cf-admin-client-secret` at manifest creation time, pulling values from CredHub via the tile installer client credentials path (`/opsmgr/${BOSH_DEPLOYMENT}/uaa/tile_installer_client_credentials`).

## Context

Smoke tests require a UAA client identity and secret (in addition to admin username/password) to authenticate against CF. This wires those credentials through the manifest template and the CI script that generates it.
